### PR TITLE
Fixed APP_PATH not finding path in CLI

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -1,5 +1,5 @@
 <?php
-define('APP_PATH', realpath('../').'/app/');
+define('APP_PATH', realpath( __DIR__.'/../').'/app/');
 // 调试模式 上线关闭  off while online
 // 调试模式会每次重新编译view模板文件，关闭后只编译一次将提高性能
 // 关闭后，每次上线后需要清理重新 ../app/runtime 文件夹，这样新模板才会生效


### PR DESCRIPTION
**问题描述：**

在CLI模式下以此方式执行成功
`cd /Users/force/Desktop/Project/mine/offline-search-engine/public && php index.php /home/crawler/new_catch`

在CLI模式下以此方式执行报错
`php /Users/force/Desktop/Project/mine/offline-search-engine/public/index.php /home/crawler/new_catch`

报错信息：module(home) controller(crawler) not found File: /Users/force/Desktop/Project/mine/offline-search-engine/phppoem/core/load.php:79

报错同时`build::initApp()`会在`/Users/force/`下自动创建`app`目录（确定为APP_PATH导致）

经定位排查到APP_PATH，发现拼接错误导致，提供此修复

**问题环境：**
Mac + PHP7.4

